### PR TITLE
Refactor preferAttributeWidth

### DIFF
--- a/config.php
+++ b/config.php
@@ -173,11 +173,9 @@ return [
             'removeUnusedCss' => [
                 'enabled' => false,
             ],
-            'preferAttributeWidth' => [
-                'table' => false,
-                'td' => false,
-                'th' => false,
-                'img' => false,
+            'keepOnlyAttributeSizes' => [
+                'width' => [],
+                'height' => [],
             ],
             'preferBgColorAttribute' => false,
         ],

--- a/config.production.php
+++ b/config.production.php
@@ -56,11 +56,9 @@ return [
                 ],
                 'uglifyClassNames' => true,
             ],
-            'preferAttributeWidth' => [
-                'table' => true,
-                'td' => true,
-                'th' => true,
-                'img' => true,
+            'keepOnlyAttributeSizes' => [
+                'width' => ['TABLE', 'TD', 'TH', 'IMG', 'VIDEO'],
+                'height' => ['TABLE', 'TD', 'TH', 'IMG', 'VIDEO'],
             ],
             'preferBgColorAttribute' => true,
         ],

--- a/config.staging.php
+++ b/config.staging.php
@@ -61,11 +61,9 @@ return [
                 ],
                 'uglifyClassNames' => false,
             ],
-            'preferAttributeWidth' => [
-                'table' => true,
-                'td' => true,
-                'th' => true,
-                'img' => true,
+            'keepOnlyAttributeSizes' => [
+                'width' => ['TABLE', 'TD', 'TH', 'IMG', 'VIDEO'],
+                'height' => ['TABLE', 'TD', 'TH', 'IMG', 'VIDEO'],
             ],
             'preferBgColorAttribute' => true,
         ],

--- a/tasks/js/after-jigsaw.js
+++ b/tasks/js/after-jigsaw.js
@@ -62,10 +62,12 @@ module.exports.processEmails = (config) => {
     let style = $('style').first();
     style.html(extraCss + style.text());
 
-    if (cleanupOpts.preferAttributeWidth) {
-      Object.entries(cleanupOpts.preferAttributeWidth).map(([k, v]) => {
-        if (v) {
-          $(k).each((i, el) => { $(el).css('width', '') });
+    if (cleanupOpts.keepOnlyAttributeSizes) {
+      Object.entries(cleanupOpts.keepOnlyAttributeSizes).map(([k, v]) => {
+        if (v.length > 0) {
+          $(v).each((i, el) => {
+            $(el).css(k, '')
+          });
         }
       });
     }


### PR DESCRIPTION
Renamed to `keepOnlyAttributeSizes`, now parses `height` too.