### PR TITLE
Remove minifier option for processing conditional comments.

### DIFF
--- a/config.php
+++ b/config.php
@@ -215,7 +215,6 @@ return [
             'preserveLineBreaks' => false,
             'collapseWhitespace' => false,
             'conservativeCollapse' => false,
-            'processConditionalComments' => false,
         ],
         'sixHex' => false,
         'altText' => false,

--- a/config.production.php
+++ b/config.production.php
@@ -65,7 +65,6 @@ return [
             'preserveLineBreaks' => false,
             'collapseWhitespace' => true,
             'conservativeCollapse' => false,
-            'processConditionalComments' => true,
         ],
         'sixHex' => true,
         'altText' => true,

--- a/config.staging.php
+++ b/config.staging.php
@@ -69,7 +69,6 @@ return [
             'preserveLineBreaks' => false,
             'collapseWhitespace' => false,
             'conservativeCollapse' => false,
-            'processConditionalComments' => false,
         ],
         'sixHex' => true,
         'altText' => true,

--- a/tasks/js/after-jigsaw.js
+++ b/tasks/js/after-jigsaw.js
@@ -97,8 +97,7 @@ module.exports.processEmails = (config) => {
       maxLineLength: minifyOpts.maxLineLength,
       collapseWhitespace: minifyOpts.collapseWhitespace,
       preserveLineBreaks: minifyOpts.preserveLineBreaks,
-      conservativeCollapse: minifyOpts.conservativeCollapse,
-      processConditionalComments: minifyOpts.processConditionalComments
+      conservativeCollapse: minifyOpts.conservativeCollapse
     });
 
     if (transformers.sixHex) {


### PR DESCRIPTION
Fixes #27.

Note: since `html-minifier` defaults `processConditionalComments` to `false`, I've removed this from both the configs _and_ from `after-jigsaw.js`. 